### PR TITLE
Set 'Output' channel name to 'Atari Compiler'

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -67,7 +67,7 @@ export const ChangeLogUri: vscode.Uri = vscode.Uri.parse(`https://marketplace.vi
 // -------------------------------------------------------------------------------------
 // Channels
 // -------------------------------------------------------------------------------------
-export const CompilerOutputChannel: vscode.OutputChannel = vscode.window.createOutputChannel("Compiler"); 
+export const CompilerOutputChannel: vscode.OutputChannel = vscode.window.createOutputChannel("Atari Compiler"); 
 
 // -------------------------------------------------------------------------------------
 // Terminal


### PR DESCRIPTION
When many extensions are in use across multiple languages, it can be challenging to locate the correct channel in the Output view. This changes the name from the generic 'Compiler' channel to 'Atari Compiler'.