### PR TITLE
Update instructions for Apple Silicon macs

### DIFF
--- a/README-macos.md
+++ b/README-macos.md
@@ -1,0 +1,111 @@
+# Atari Dev Studio - macOS build instruction
+
+Atari Dev Studio does not currently include the latest `*.Darwin.arm64` (Apple silicon macs) binaries.
+
+Use these instructions to manually build the latest binaries from source and configure Atari Dev Studio to use your locally built binaries.
+
+
+# Install Atari Dev Studio
+
+1. Use VS Code to install the [Atari Dev Studio](https://marketplace.visualstudio.com/items?itemName=chunkypixel.atari-dev-studio) extension.
+2. Optionally build a `*.bas` (batari Basic) program and make note of the batari Basic and dasm version strings reported in the compiler
+   output window, for comparison later. These might look something like this:
+
+```
+Found dasm version: DASM 2.20.15-SNAPSHOT
+batari Basic v1.6-SNAPSHOT (c)2021
+```
+
+# Create a directory for your locally built binaries
+
+1. Create a directory to store your locally built batari Basic and dasm binaries. You'll later configure Atari Dev Studio to use this directory.
+
+```
+mkdir ~/mybatariBasic
+```
+
+# batari Basic build and copy
+
+1. Change to your preferred working directory.
+
+```
+cd
+```
+
+2. Clone the batari Basic repo and build binaries.
+
+```
+git clone git@github.com:batari-Basic/batari-Basic.git
+cd batari-Basic
+make
+```
+
+3. Copy files to your local batari Basic directory.
+
+```
+cp 2600basic.sh ~/mybatariBasic/
+cp -r includes ~/mybatariBasic/
+
+OSTYPE=$(uname -s)
+ARCH=$(uname -m)
+cp 2600basic ~/mybatariBasic/2600basic.$OSTYPE.$ARCH
+cp bbfilter ~/mybatariBasic/bbfilter.$OSTYPE.$ARCH
+cp optimize ~/mybatariBasic/optimize.$OSTYPE.$ARCH
+cp postprocess ~/mybatariBasic/postprocess.$OSTYPE.$ARCH
+cp preprocess ~/mybatariBasic/preprocess.$OSTYPE.$ARCH
+```
+
+4. Optionally, delete the cloned batari-Basic repo.
+
+```
+cd ..
+rm -rf batari-Basic
+```
+
+# dasm build and copy
+
+1. Change to your preferred working directory.
+
+```
+cd
+```
+
+2. Clone the dasm repo and build.
+
+```
+git clone git@github.com:dasm-assembler/dasm.git
+make
+```
+
+3. Copy dasm to your local batari Basic directory.
+
+```
+cp bin/dasm ~/mybatariBasic/dasm.$OSTYPE.$ARCH
+```
+
+4. Optionally, delete the cloned dasm-assembler repo.
+
+```
+cd ..
+rm -rf dasm-assembler
+```
+
+# Configure Atari Dev Studio
+
+1. In VS Code, open Settings (`CMD-,` or `CMD-SHIFT-P` > `Settings`)
+2. Search for `Batari Basic: Folder` (under `Atari-dev-studio` > `Compiler`).
+   Or, follow this URL to go straight there: `vscode://settings/atari-dev-studio.compiler.batariBasic.folder`.
+3. Specify your local batari Basic folder. Use the full qualified path name. VS Code will *not* understand `~` to mean your home directory.
+   For example, `/Users/yourusername/mybatariBasic/`.
+
+# Verify that everything is working
+
+1. In VS Code, open a `*.bas` (batari Basic) file.
+2. Press `F5` to compile and launch your program.
+3. Verify the batari Basic and dasm version strings mentioned in the compiler output are the latest.
+   These versions might look something like this:
+
+```
+Found dasm version: DASM 2.20.15-SNAPSHOT
+batari Basic v1.8 (c)2025
+```

--- a/README.md
+++ b/README.md
@@ -30,11 +30,24 @@ Visual Studio Code (VS Code) is a streamlined code editor with support for devel
 ### Which OSs are supported?
 VS Code is a cross-platform application which runs on Windows, Linux and macOS. See [requirements](https://code.visualstudio.com/docs/supporting/requirements) for the supported versions.
 
-> Note: Linux users on 64-bit systems will be required to install the 32-bit compatibility libraries on your system to ensure everything will run as expected. 
+#### Windows
+No special considerations. Windows users should be able to use Atari Dev Studio as is.
 
-> Note: macOS users require a 64-bit operating system to fully utilise all features of Atari Dev Studio and will be required to install the SDL libraries on your system to ensure the A7800 emulator will run as expected.
+#### Linux
+Linux users on 64-bit systems will be required to install the 32-bit compatibility libraries on your system to ensure everything will run as expected.
 
-> Note: M1 based Mac users will need to install the INTEL CHIP version of VS Code before installing Atari Dev Studio.  Also thanks to Scott Lahteine (thinkyhead) the current dev stack should now have compatibility with the M1 chip (ARM64) and includes most of the recent versions of bB, 7800basic, Stella and dasm.  See [here](https://atariage.com/forums/topic/333127-ataribasic-will-it-run-on-the-m1-mac) for further discussion around the potential issues you may encounter.
+#### macOS
+macOS users require a 64-bit operating system to fully utilise all features of Atari Dev Studio and will be required to install the SDL libraries on your system to ensure the A7800 emulator will run as expected.
+
+Mac computers with Apple silicon currently have a few options:
+
+1.  Thanks to Scott Lahteine (thinkyhead), Atari Dev Studio now includes `*.Darwin.arm64` (Apple silicon) binaries of relatively recent versions of bB, 7800basic, Stella and dasm.
+    Note, these the are *not* the latest versions of these tools. See the atariage [discussion](https://atariage.com/forums/topic/333127-ataribasic-will-it-run-on-the-m1-mac)
+    around additional issues you might encounter.
+2.  Manually build `*.Darwin.arm64` (Apple silicon) binaries from source and configure Atari Dev Studio to use use your locally built binaries. See `README-macos.md` for instructions.
+3.  Install and run the INTEL CHIP version of VS Code instead of the Apple Silicon version. This will cause Atari Dev Studio to use the Intel binaries, `*.Darwin.x86` / `*.Darwin.x64`.
+
+Older Mac computers with Intel chips should be able to use Atari Dev Studio as is.
 
 ### Installing the extension
 Once you have installed VS Code (available [here](https://code.visualstudio.com/Download)), open the VS Code program and complete the following:


### PR DESCRIPTION
Partially addresses outdated instructions mentioned in https://github.com/chunkypixel/atari-dev-studio/issues/58